### PR TITLE
Fixed minor bug in annotateFiles.py

### DIFF
--- a/annotateFiles.py
+++ b/annotateFiles.py
@@ -69,7 +69,7 @@ def processFiles(dir_name, mode, prefix):
                 xlsx = pd.ExcelFile(filename)
                 temp = xlsx.parse()
                 temp['Strand'] = 0
-                temp['Unique_ID'] = temp['chr'].astype(str) + temp['start'].astype(str)
+                temp['Unique_ID'] = temp['chr'].astype(str) + '.' + temp['start'].astype(str)
                 header = ['Unique_ID', 'chr', 'start', 'stop', 'Strand', 'q value', 'mean diff (g1-g2)',
                           'no. CpGs', 'p (MWU)', 'p (2D KS)', 'mean g1', 'mean g2', 'distance', 'gene ID',
                           'gene name', 'strand']

--- a/annotateFiles.py
+++ b/annotateFiles.py
@@ -48,8 +48,8 @@ def processFiles(dir_name, mode, prefix):
                 temp2['Strand'] = 0
                 #temp1['Unique_ID'] = temp1[['Chrom', 'Start']].apply(lambda x: '.'.join(x), axis = 1)
                 #temp2['Unique_ID'] = temp2[['Chrom', 'Start']].apply(lambda x: '.'.join(x), axis = 1)
-                temp1['Unique_ID'] = temp1['Chrom'] + '.' + temp1['Start'].astype(str)
-                temp2['Unique_ID'] = temp2['Chrom'] + '.' + temp2['Start'].astype(str)
+                temp1['Unique_ID'] = temp1['Chrom'].astype(str) + '.' + temp1['Start'].astype(str)
+                temp2['Unique_ID'] = temp2['Chrom'].astype(str) + '.' + temp2['Start'].astype(str)
                 header = ['Unique_ID', 'Chrom', 'Start', 'End', 'Strand', 'Gene', 'ID', 'Accession', 'Class', 'ExNum',
                           'log2(FC)']
                 outfile1 = os.path.splitext(filename)[0] + sheet_names[0] + '.tsv'
@@ -69,7 +69,7 @@ def processFiles(dir_name, mode, prefix):
                 xlsx = pd.ExcelFile(filename)
                 temp = xlsx.parse()
                 temp['Strand'] = 0
-                temp['Unique_ID'] = temp['chr'] + temp['start'].astype(str)
+                temp['Unique_ID'] = temp['chr'].astype(str) + temp['start'].astype(str)
                 header = ['Unique_ID', 'chr', 'start', 'stop', 'Strand', 'q value', 'mean diff (g1-g2)',
                           'no. CpGs', 'p (MWU)', 'p (2D KS)', 'mean g1', 'mean g2', 'distance', 'gene ID',
                           'gene name', 'strand']


### PR DESCRIPTION
In `annotateFiles.py`, a unique identifier is created for each feature by concatenating the chromosome name and start position of a feature:
```py3
temp1['Unique_ID'] = temp1['Chrom'] + '.' + temp1['Start'].astype(str)
```
This works when the data in the 'chrom' column are of type `str`. However, if the chromosomes are named "1, 2, 3, ..." instead of the conventional "chr1, chr2, chr3...", then `pandas` will load this column as type `int` and cause the following error:

```
Starting annotateFiles.py

metilene mode selected

Converting file filename.xlsx to tsv format...

Traceback (most recent call last):
  File "/apps/gcc/5.2.0/python/3.6.1/lib/python3.6/site-packages/pandas/core/ops.py", line 676, in na_op
    result = expressions.evaluate(op, str_rep, x, y, **eval_kwargs)
  File "/apps/gcc/5.2.0/python/3.6.1/lib/python3.6/site-packages/pandas/core/computation/expressions.py",
 line 204, in evaluate
    return _evaluate(op, op_str, a, b, **eval_kwargs)
  File "/apps/gcc/5.2.0/python/3.6.1/lib/python3.6/site-packages/pandas/core/computation/expressions.py",
 line 64, in _evaluate_standard
    return op(a, b)
TypeError: unsupported operand type(s) for +: 'int' and 'str'
```
In this PR, I used a simple fix to force the data in the 'Chrom' column to be `str`:

```py3
temp1['Unique_ID'] = temp1['Chrom'].astype(str) + temp1['start'].astype(str)
```

This change has been tested on both previously working files and on the files that caused this error.